### PR TITLE
Define graphql types and mutations for users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ gem 'graphiql-rails', '1.5.0', group: :development
 gem 'pry'
 
 gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
+
+gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    bcrypt (3.1.12)
     bindex (0.7.0)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -149,7 +150,7 @@ GEM
     regexp_parser (1.5.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -218,6 +219,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -5,7 +5,8 @@ class GraphqlController < ApplicationController
     operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
-      # current_user: current_user,
+      session: session,
+      current_user: current_user
     }
     result = GraphqlSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
@@ -15,6 +16,18 @@ class GraphqlController < ApplicationController
   end
 
   private
+
+  def current_user
+    # if we want to change the sign-in strategy, this is the place to do it
+    return unless session[:token]
+
+    crypt = ActiveSupport::MessageEncryptor.new(Rails.application.credentials.secret_key_base.byteslice(0..31))
+    token = crypt.decrypt_and_verify session[:token]
+    user_id = token.gsub('user-id:', '').to_i
+    User.find_by id: user_id
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
 
   # Handle form data, JSON body, or a blank value
   def ensure_hash(ambiguous_param)

--- a/app/graphql/mutations/create_link.rb
+++ b/app/graphql/mutations/create_link.rb
@@ -11,7 +11,8 @@ module Mutations
     def resolve(description: nil, url: nil)
       Link.create!(
         description: description,
-        url: url
+        url: url,
+        user: context[:current_user]
       )
     end
   end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,0 +1,21 @@
+module Mutations
+  class CreateUser < BaseMutation
+    # define input types
+    class AuthProviderSignupData < Types::BaseInputObject
+      argument :email, Types::AuthProviderEmailInput, required: false
+    end
+
+    argument :name, String, required: true
+    argument :auth_provider, AuthProviderSignupData, required: false
+
+    type Types::UserType
+
+    def resolve(name: nil, auth_provider: nil)
+      User.create!(
+        name: name,
+        email: auth_provider&.[](:email)&.[](:email),
+        password: auth_provider&.[](:email)&.[](:password)
+      )
+    end
+  end
+end

--- a/app/graphql/mutations/sign_in_user.rb
+++ b/app/graphql/mutations/sign_in_user.rb
@@ -1,0 +1,29 @@
+module Mutations
+  # Mutation to sign in a user
+  class SignInUser < BaseMutation
+    null true
+
+    argument :email, Types::AuthProviderEmailInput, required: false
+
+    field :token, String, null: true
+    field :user, Types::UserType, null: true
+
+    def resolve(email: nil)
+      return unless email
+
+      user = User.find_by email: email[:email]
+
+      return unless user
+
+      return unless user.authenticate(email[:password])
+
+      crypt = ActiveSupport::MessageEncryptor.new(Rails.application.credentials.secret_key_base.byteslice(0..31))
+      token = crypt.encrypt_and_sign("user-id:#{ user.id }")
+
+      context[:session][:token] = token
+
+      { user: user, token: token }
+    end
+  end
+end
+

--- a/app/graphql/types/auth_provider_email_input.rb
+++ b/app/graphql/types/auth_provider_email_input.rb
@@ -1,0 +1,9 @@
+module Types
+  # Create a type for the authentication provider
+  class AuthProviderEmailInput < BaseInputObject
+    graphql_name 'AUTH_PROVIDER_EMAIL'
+
+    argument :email, String, required: true
+    argument :password, String, required: true
+  end
+end

--- a/app/graphql/types/link_type.rb
+++ b/app/graphql/types/link_type.rb
@@ -4,5 +4,6 @@ module Types
     field :id, ID, null: false
     field :url, String, null: false
     field :description, String, null: false
+    field :posted_by, UserType, null: true, method: :user
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,7 @@
 module Types
   class MutationType < BaseObject
     field :create_link, mutation: Mutations::CreateLink
+    field :create_user, mutation: Mutations::CreateUser
+    field :signin_user, mutation: Mutations::SignInUser
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,10 +3,14 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
     field :all_links, [LinkType], null: false
     def all_links
       Link.all
+    end
+
+    field :all_users, [UserType], null: false
+    def all_users
+      User.all
     end
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,7 @@
+module Types
+  class UserType < BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :email, String, null: false
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,3 +1,5 @@
 class Link < ApplicationRecord
   validates :url, presence: true, uniqueness: true
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+end

--- a/db/migrate/20190521123917_create_users.rb
+++ b/db/migrate/20190521123917_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190521191153_add_user_id_link.rb
+++ b/db/migrate/20190521191153_add_user_id_link.rb
@@ -1,0 +1,7 @@
+class AddUserIdLink < ActiveRecord::Migration[5.2]
+  def change
+    change_table :links do |t|
+      t.references :user, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_21_064506) do
+ActiveRecord::Schema.define(version: 2019_05_21_191153) do
 
   create_table "links", force: :cascade do |t|
     t.string "url"
     t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_links_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/test/graphql/mutations/create_user_test.rb
+++ b/test/graphql/mutations/create_user_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+# Test for link mutations
+class Mutations::CreateUserTest < ActiveSupport::TestCase
+
+  def perform(args = {})
+    Mutations::CreateUser.new(object: nil, context: {}).resolve(args)
+  end
+
+  test 'create a new user' do
+    user = perform(
+      name: 'Test User',
+      auth_provider: {
+        email: {
+          email: 'test@user.com',
+          password: '12345'
+        }
+      },
+    )
+
+    assert user.persisted?
+    assert_equal user.name, 'Test User'
+    assert_equal user.email, 'test@user.com'
+  end
+end

--- a/test/graphql/mutations/signin_user_test.rb
+++ b/test/graphql/mutations/signin_user_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+# Test for link mutations
+class Mutations::SignInUserTest < ActiveSupport::TestCase
+
+  def perform(args = {})
+    Mutations::SignInUser.new(object: nil, context: { session: {} }).resolve(args)
+  end
+
+  def create_user
+    @user = User.create!(
+      name: 'Test User',
+      email: 'test@user.com',
+      password: '12345'
+    )
+  end
+
+  def successfuly_login_user
+    @result = perform(
+      email: {
+        email: @user.email,
+        password: @user.password
+      }
+    )
+  end
+
+  def unsuccessfuly_login_user
+    @failure_response = perform(
+      email: {
+        email: 'wrong email', 
+        password: 'wrong password'
+      }
+    )
+  end
+
+  test 'successful sign in' do
+    create_user
+    successfuly_login_user
+    assert @result[:token].present?
+    assert_equal @result[:user], @user
+  end
+
+  test 'unsucceessful login due to missing credentials' do
+    create_user
+    assert_nil perform
+  end
+
+  test 'unsucceessful login due to wrong email and password' do
+    create_user
+    assert_nil @failure_response
+  end
+end


### PR DESCRIPTION
**Description**

Add authentication in the application by defining types and mutations for users

- define types for users
- define mutations for users
- associate links posted to users
- store token generated after login